### PR TITLE
code review session 1 fixes. mostly on root.go and open.go but had to…

### DIFF
--- a/cmd/bgpmon/cmd/close.go
+++ b/cmd/bgpmon/cmd/close.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ func closeSess(cmd *cobra.Command, args []string) {
 	if bc, clierr := newBgpmonCli(bgpmondHost, bgpmondPort); clierr != nil {
 		fmt.Printf("Error: %s\n", clierr)
 	} else {
-		defer bc.Close()
+		defer bc.close()
 		emsg := &pb.CloseSessionRequest{
 			SessionId: sessID,
 		}

--- a/cmd/bgpmon/cmd/get.go
+++ b/cmd/bgpmon/cmd/get.go
@@ -60,7 +60,7 @@ func get(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Error: %s\n", clierr)
 		return clierr
 	}
-	defer moncli.Close()
+	defer moncli.close()
 	ctx, cancel := getBackgroundCtxWithCancel()
 	// First get the session info
 	pbr := &pb.GetRequest{Type: pb.GetRequest_CAPTURE, SessionId: sessID,

--- a/cmd/bgpmon/cmd/getInfo.go
+++ b/cmd/bgpmon/cmd/getInfo.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
 
 	"github.com/spf13/cobra"
@@ -22,7 +23,7 @@ func getInfoFunc(cmd *cobra.Command, args []string) {
 		fmt.Printf("Error: %s\n", clierr)
 	}
 
-	defer bc.Close()
+	defer bc.close()
 	msg := &pb.SessionInfoRequest{SessionId: args[0]}
 	ctx, cancel := getCtxWithCancel()
 	defer cancel()

--- a/cmd/bgpmon/cmd/listAvailable.go
+++ b/cmd/bgpmon/cmd/listAvailable.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
 
 	"github.com/spf13/cobra"
@@ -22,7 +23,7 @@ func listAvail(cmd *cobra.Command, args []string) {
 	if bc, clierr := newBgpmonCli(bgpmondHost, bgpmondPort); clierr != nil {
 		fmt.Printf("Error: %s\n", clierr)
 	} else {
-		defer bc.Close()
+		defer bc.close()
 		emsg := &pb.Empty{}
 		ctx, cancel := getCtxWithCancel()
 		defer cancel()

--- a/cmd/bgpmon/cmd/listOpen.go
+++ b/cmd/bgpmon/cmd/listOpen.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
 
 	"github.com/spf13/cobra"
@@ -21,7 +22,7 @@ func listOpen(cmd *cobra.Command, args []string) {
 	if bc, clierr := newBgpmonCli(bgpmondHost, bgpmondPort); clierr != nil {
 		fmt.Printf("Error: %s\n", clierr)
 	} else {
-		defer bc.Close()
+		defer bc.close()
 		emsg := &pb.Empty{}
 		ctx, cancel := getCtxWithCancel()
 		defer cancel()

--- a/cmd/bgpmon/cmd/root.go
+++ b/cmd/bgpmon/cmd/root.go
@@ -1,16 +1,20 @@
+// Package cmd is the package that provides implementations for the bgpmon client
+// commands. It utilizes the cobra and viper configuration frameworks which
+// make it possible for commands to either be specified by command line options
+// or configuration files.
 package cmd
 
 import (
 	"context"
 	"fmt"
-	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
-	"google.golang.org/grpc"
 	"os"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
+	pb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -20,6 +24,8 @@ var (
 	rpcTimeoutSecs uint32
 )
 
+// bgpmonCli is a structure that unifies a grpc connection with the bgpmond
+// client protobuf specification from the netsec-protobufs repository.
 type bgpmonCli struct {
 	conn *grpc.ClientConn
 	cli  pb.BgpmondClient
@@ -36,15 +42,20 @@ func newBgpmonCli(host string, port uint32) (*bgpmonCli, error) {
 	return ret, nil
 }
 
-func (b *bgpmonCli) Close() {
-	b.conn.Close()
+func (b *bgpmonCli) close() {
+	if err := b.conn.Close(); err != nil {
+		fmt.Printf("Error:%s while closing the connection to bgpmond", err)
+	}
 }
 
-// helper func to return a context with a cancelfunc with timeout
+// helper func to return a context with a cancelfunc with timeout.
 func getCtxWithCancel() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Duration(rpcTimeoutSecs)*time.Second)
 }
 
+// getBackgroundCtxWithCancel derives a new context for the background one, alongside with a cancel function
+// that can be invoked by a holder. The purpose of this context is to pass cancellation request from the RPC
+// client events to the server components that can be running on another host.
 func getBackgroundCtxWithCancel() (context.Context, context.CancelFunc) {
 	return context.WithCancel(context.Background())
 }
@@ -67,10 +78,10 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.bgpmon.yaml)")
-	rootCmd.PersistentFlags().StringVarP(&bgpmondHost, "host", "H", "127.0.0.1", "bgpmond host to connect to (default is 127.0.0.1)")
-	rootCmd.PersistentFlags().Uint32VarP(&bgpmondPort, "port", "P", 12289, "bgpmond port to connect to (default is 6060)")
-	rootCmd.PersistentFlags().Uint32VarP(&rpcTimeoutSecs, "rpcTimeout", "t", 5, "seconds in which an RPC request should timeout")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "$HOME/.bgpmon.yaml", "Config file")
+	rootCmd.PersistentFlags().StringVarP(&bgpmondHost, "host", "h", "127.0.0.1", "bgpmond host to connect to")
+	rootCmd.PersistentFlags().Uint32VarP(&bgpmondPort, "port", "p", 6060, "bgpmond port to connect to")
+	rootCmd.PersistentFlags().Uint32VarP(&rpcTimeoutSecs, "rpcTimeout", "t", 5, "Seconds in which an RPC request should timeout")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -91,10 +102,13 @@ func initConfig() {
 		viper.SetConfigName(".bgpmon")
 	}
 
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv() // Read in environment variables that match.
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	} else if !os.IsNotExist(err) { // The config file exists but it errored in parsing.
+		fmt.Printf("Error:%s in parsing config file:%s\n", viper.ConfigFileUsed(), err)
+		os.Exit(1)
 	}
 }

--- a/cmd/bgpmon/cmd/write.go
+++ b/cmd/bgpmon/cmd/write.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"sync"
+
 	monpb "github.com/CSUNetSec/netsec-protobufs/bgpmon/v2"
 	"github.com/CSUNetSec/protoparse/fileutil"
 	"github.com/CSUNetSec/protoparse/filter"
 	swg "github.com/remeh/sizedwaitgroup"
-	"io"
-	"sync"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,7 @@ func writeFunc(cmd *cobra.Command, args []string) {
 		fmt.Printf("Error: %s\n", clierr)
 		return
 	}
-	defer bc.Close()
+	defer bc.close()
 
 	ctx, cancel := getBackgroundCtxWithCancel()
 	// First get the session info


### PR DESCRIPTION
… touch the rest of the client due to bgpmonCli.close() not being exported now.

removing the default strings since viper prints them

flattening if/else as per new recommendations

capitalizing short viper commands where appropriate

close() not returning an error, just logging it